### PR TITLE
Never automatically reduce maxNumber

### DIFF
--- a/hostfactory/host_provider/src/version.py
+++ b/hostfactory/host_provider/src/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 
 
 def get_version():


### PR DESCRIPTION
Never automatically reduce maxNumber for a Template while HostFactory… is running - it can cause HF to hang and require a manual restart.   Instead users should manaully restart HF if they need to reduce maxNumber or remove SKUs from the allowed list.